### PR TITLE
README update & STYLE facilitator added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules
 .DS_Store
 .tags*
 npm-debug.log
-
+style/main.css

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,14 @@ module.exports = function(grunt){
             bower: {
                 files: ['bower_components/*'],
                 tasks: ['wiredep']
-            }
+            },
+            css: {
+                files: './style/*.styl',
+                tasks: ['stylus'],
+                options: {
+                    livereload: true
+                }
+            },
         },
         copy: {
             main: {
@@ -21,10 +28,21 @@ module.exports = function(grunt){
                     {   expand: true, src: ['./js/**'], dest: 'docs/' },
                     {   expand: true, src: ['./data/**'], dest: 'docs/' },
                     {   expand: true, src: ['./index.html'], dest: 'docs/' },
+                    {   expand: true, src: ['./style/*.css', '!./style/*.styl'], dest: 'docs/' }
                 ]
+            }
+        },
+        stylus: {
+            compile: {
+                options: {
+                    compress: true
+                },
+                files: {
+                    'style/main.css': ['style/*.styl']
+                }
             }
         }
     })
-    grunt.registerTask('default', ['wiredep', 'watch']);
-    grunt.registerTask('build', ['copy']);
+    grunt.registerTask('default', ['wiredep', 'stylus', 'watch']);
+    grunt.registerTask('build', ['stylus', 'copy']);
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #Lisk Italian Group Website
-###With love by dakk (2324852447570841050L) and liskit delegates (10310263204519541551L)
+###With love by dakk (2324852447570841050L) and liskit (10310263204519541551L) delegates.
 
 This is the Lisk Italian Group Website repository. The website aims to track all the projects related to the Lisk ecosystem. 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 #Lisk Italian Group Website
+###With love by dakk (2324852447570841050L) and liskit delegates (10310263204519541551L)
 
 This is the Lisk Italian Group Website repository. The website aims to track all the projects related to the Lisk ecosystem. 
 

--- a/docs/data/projects.json
+++ b/docs/data/projects.json
@@ -29,7 +29,7 @@
     {
         "name": "lisk-js-autorebuilder",
         "description": "Lisk node anti-fork made in Javascript",
-        "type": "bot",
+        "type": "script",
         "stage": "production",
         "repository": "https://github.com/andreafspeziale/lisk-js-autorebuilder",
         "license": "MIT",
@@ -74,7 +74,7 @@
     {
         "name": "lisk-explorer",
         "description": "Lisk network explorer",
-        "type": "webservice",
+        "type": "script",
         "stage": "production",
         "repository": "https://github.com/andreafspeziale/lisk-explorer.git",
         "license": "MIT",
@@ -91,8 +91,8 @@
     },
     {
         "name": "liskitbash",
-        "description": "Smart bash wrapper for Lisk update",
-        "type": "bot",
+        "description": "Smart bash wrapper for Lisk installation and update",
+        "type": "script",
         "stage": "development",
         "repository": "https://github.com/andreafspeziale/liskitbash.git",
         "license": "MIT",

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,17 +13,13 @@
   	<link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
   	<!-- endbower -->
 
+  	<link rel="stylesheet" type="text/css" href="style/main.css">
+
 	<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
 	<!--[if lt IE 9]>
 	  <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 	  <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 	<![endif]-->
-
-	<style>
-		body {
-			background-color: #fff;
-		}
-	</style>
   </head>
   <body>
 	<div class="container" ng-controller="indexController">

--- a/docs/style/main.css
+++ b/docs/style/main.css
@@ -1,0 +1,1 @@
+html,body{width:100%;height:100%}

--- a/index.html
+++ b/index.html
@@ -13,17 +13,13 @@
   	<link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
   	<!-- endbower -->
 
+  	<link rel="stylesheet" type="text/css" href="style/main.css">
+
 	<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
 	<!--[if lt IE 9]>
 	  <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 	  <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 	<![endif]-->
-
-	<style>
-		body {
-			background-color: #fff;
-		}
-	</style>
   </head>
   <body>
 	<div class="container" ng-controller="indexController">

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-stylus": "^1.2.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-wiredep": "~2.0.0",
     "load-grunt-tasks": "^3.2.0"

--- a/style/main.css
+++ b/style/main.css
@@ -1,0 +1,1 @@
+html,body{width:100%;height:100%}

--- a/style/main.css
+++ b/style/main.css
@@ -1,1 +1,0 @@
-html,body{width:100%;height:100%}

--- a/style/main.styl
+++ b/style/main.styl
@@ -1,0 +1,3 @@
+html, body
+  width 100%
+  height 100%


### PR DESCRIPTION
Added a style stylus file that will be compiled while grunt is running during development.
Grunt build command will copy in docs only the compiled css file.

Run an npm install, grunt and start developing again.